### PR TITLE
Add Docker Compose file to spawn Consul process

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: "3.3"
+services:
+  consul:
+    environment:
+      CONSUL_BIND_INTERFACE: eth0
+      CONSUL_LOCAL_CONFIG: >
+        {
+          "bind_addr": "eth0",
+          "client_addr": "0.0.0.0",
+          "enable_script_checks": true,
+          "service": {
+            "checks": [
+              {
+                "interval": "10s",
+                "tcp": "localhost:8080"
+              }
+            ],
+            "name": "web",
+            "port": 8080
+          },
+          "ui": true
+        }
+    image: consul
+    ports:
+    - "8500:8500"


### PR DESCRIPTION
The Docker Compose file spawns a Consul Agent using the configuration defined in the Compose file. The configuration registers a service named 'web' that explicitly fails a health check.

Verification steps:

    $ docker-compose up

Visit: [http://localhost:8500](http://localhost:8500)

Verify the `web` service health check is failing.

![screen shot 2017-11-16 at 1 50 16 pm](https://user-images.githubusercontent.com/2184329/32909651-1d121050-cad5-11e7-8013-bd9396ee0737.png)

Closes #1