### PR TITLE
 Add Consul Watch configuration to Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: "3.3"
 services:
   consul:
+    depends_on:
+    - gentry
     environment:
       CONSUL_BIND_INTERFACE: eth0
       CONSUL_LOCAL_CONFIG: >
@@ -18,8 +20,23 @@ services:
             "name": "web",
             "port": 8080
           },
-          "ui": true
+          "ui": true,
+          "watches": [
+            {
+              "handler": "/go/gentry",
+              "type": "checks"
+            }
+          ]
         }
     image: consul
     ports:
-    - "8500:8500"
+    - 8500:8500
+    volumes:
+    - shared:/go
+  gentry:
+    build: .
+    command: go build -v
+    volumes:
+    - shared:/go/bin
+volumes:
+  shared:


### PR DESCRIPTION
This configuration monitors the checks of a given service or those in a specific state. The service `gentry` compiles the application and creates a binary executable in the `/go/bin` directory. The `consul` service invokes the binary executable in the `watches` configuration defined in the `CONSUL_LOCAL_CONFIG` environment variable.

**Verification steps:**

    $ docker-compose up

The service `gentry` *should* exit with code 0, and the service `consul` should invoke the watch handler: `[DEBUG] agent: watch handler '/go/gentry' output:`. The output is empty since [`main.go`](https://github.com/pennsignals/gentry/blob/design/docker-compose-consul-health-check/main.go) does not have any statements.

<img width="682" alt="screen shot 2017-11-27 at 9 51 54 am" src="https://user-images.githubusercontent.com/2184329/33272720-fece4c6c-d358-11e7-9882-b45693c5170c.png">

Closes #3