### PR TITLE
 Prefix 'State' constants for more suitable naming

### DIFF
--- a/health.go
+++ b/health.go
@@ -13,22 +13,22 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	}
 	switch state {
 	case "critical":
-		*s = Critical
+		*s = StateCritical
 	case "passing":
-		*s = Passing
+		*s = StatePassing
 	case "warning":
-		*s = Warning
+		*s = StateWarning
 	default:
-		*s = Any
+		*s = StateAny
 	}
 	return nil
 }
 
 const (
-	Any State = iota
-	Critical
-	Passing
-	Warning
+	StateAny State = iota
+	StateCritical
+	StatePassing
+	StateWarning
 )
 
 type Check struct {

--- a/health_test.go
+++ b/health_test.go
@@ -29,7 +29,7 @@ func TestTypeStateDecode(t *testing.T) {
 	if err := json.Unmarshal(data, &checks); err != nil {
 		t.Error(err)
 	}
-	for i, expected := range []State{Any, Critical, Passing, Warning} {
+	for i, expected := range []State{StateAny, StateCritical, StatePassing, StateWarning} {
 		actual := checks[i].Status
 		if expected != actual {
 			t.Errorf("main: expected type %d, got %d instead", expected, actual)


### PR DESCRIPTION
Rename `Critical`, `Passing`, `Warning`, and `Any` to `StateCritical`, `StatePassing`, `StateWarning`, and `StateAny`, respectively.

**Verification steps:**

    $ go test -v ./...