### PR TITLE
Add Slack type PostMessage

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -20,6 +20,10 @@ type Attachment struct {
 
 type Attachments []*Attachment
 
+func (a *Attachments) Add(attachment *Attachment) {
+	*a = append(*a, attachment)
+}
+
 type Color string
 
 const (
@@ -39,4 +43,21 @@ type Field struct {
 	Value string `json:"value"`
 }
 
-type Fields []Field
+type Fields []*Field
+
+type PostMessage struct {
+	AsUser         bool        `json:"as_user"`
+	Attachments    Attachments `json:"attachments"`
+	Channel        string      `json:"channel"`
+	IconEmoji      string      `json:"icon_emoji"`
+	IconURL        string      `json:"icon_url"`
+	LinkNames      bool        `json:"link_names"`
+	Parse          string      `json:"parse"`
+	ReplyBroadcast bool        `json:"reply_broadcast"`
+	Text           string      `json:"text"`
+	ThreadTS       float32     `json:"thread_ts"`
+	Token          string      `json:"token"`
+	UnfurlLinks    bool        `json:"unfurl_links"`
+	UnfurlMedia    bool        `json:"unfurl_media"`
+	Username       string      `json:"username"`
+}

--- a/slack_test.go
+++ b/slack_test.go
@@ -38,10 +38,17 @@ func TestTypeAttachmentDecode(t *testing.T) {
 	if err := json.Unmarshal(data, &attachments); err != nil {
 		t.Error(err)
 	}
-	var actual, expected string
-	actual = attachments[0].Color.String()
-	expected = ColorDanger.String()
+	actual, expected := attachments[0].Color.String(), ColorDanger.String()
 	if expected != actual {
 		t.Errorf("main: expected %s, got %s", expected, actual)
+	}
+}
+
+func TestMessageAttachmentsAdd(t *testing.T) {
+	var message PostMessage
+	message.Attachments.Add(new(Attachment))
+	actual, expected := len(message.Attachments), 1
+	if expected != actual {
+		t.Errorf("main: expected %d, got %d", expected, actual)
 	}
 }


### PR DESCRIPTION
Add convenience method for appending `Attachment` objects to existing `Attachments` slices. Update type `Fields` to be a slice of pointers of type `Field`.

**Verification steps:**

Test using native go binary:

    $ go test -v ./...

Test using a Docker container:

    $ docker run --rm -v "$PWD":/usr/src/gentry -w /usr/src/gentry golang go test -v ./...

<img width="682" alt="screen shot 2017-11-27 at 3 15 44 pm" src="https://user-images.githubusercontent.com/2184329/33287212-fd8f0bca-d385-11e7-95db-4b5ecf491aaf.png">

Closes #15