### PR TITLE
Allow Attachments.Add to take multiple arguments

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -20,8 +20,8 @@ type Attachment struct {
 
 type Attachments []*Attachment
 
-func (a *Attachments) Add(attachment *Attachment) {
-	*a = append(*a, attachment)
+func (a *Attachments) Add(attachments ...*Attachment) {
+	*a = append(*a, attachments...)
 }
 
 type Color string


### PR DESCRIPTION
If approved, this pull request updates the type signature of the `Attachments.Add` method to accept any number of [trailing arguments](https://en.wikipedia.org/wiki/Variadic_function#Example_in_Go) of type `Attachment`.

**Verification steps:**

Test using native go binary:

    $ go test -v ./...

Test using a Docker container:

    $ docker run --rm -v "$PWD":/usr/src/gentry -w /usr/src/gentry golang go test -v ./...