### PR TITLE
Update slack_test.go

### DIFF
--- a/slack_test.go
+++ b/slack_test.go
@@ -5,50 +5,19 @@ import (
 	"testing"
 )
 
-func TestTypeAttachmentDecode(t *testing.T) {
-	// Sample Attachment response from: https://api.slack.com/docs/message-attachments
-	data := []byte(`
-		[
-			{
-				"author_icon": "http://flickr.com/icons/bobby.jpg",
-				"author_link": "http://flickr.com/bobby/",
-				"author_name": "Bobby Tables",
-				"color": "danger",
-				"fallback": "Required plain-text summary of the attachment.",
-				"fields": [
-					{
-						"short": false,
-						"title": "Priority",
-						"value": "High"
-					}
-				],
-				"footer": "Slack API",
-				"footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png",
-				"image_url": "http://my-website.com/path/to/image.jpg",
-				"pretext": "Optional text that appears above the attachment block",
-				"text": "Optional text that appears within the attachment",
-				"thumb_url": "http://example.com/path/to/thumb.png",
-				"title": "Slack API Documentation",
-				"title_link": "https://api.slack.com/",
-				"ts": 123456789
-			}
-		]
-	`)
+func TestTypeAttachmentEncode(t *testing.T) {
 	var attachments Attachments
-	if err := json.Unmarshal(data, &attachments); err != nil {
+	attachments.Add(&Attachment{Color: ColorDanger})
+	message := &PostMessage{Attachments: attachments}
+	b, err := json.Marshal(message)
+	if err != nil {
 		t.Error(err)
 	}
-	actual, expected := attachments[0].Color.String(), ColorDanger.String()
+	if err := json.Unmarshal(b, &message); err != nil {
+		t.Error(err)
+	}
+	actual, expected := message.Attachments[0].Color.String(), "danger"
 	if expected != actual {
 		t.Errorf("main: expected %s, got %s", expected, actual)
-	}
-}
-
-func TestMessageAttachmentsAdd(t *testing.T) {
-	var message PostMessage
-	message.Attachments.Add(new(Attachment))
-	actual, expected := len(message.Attachments), 1
-	if expected != actual {
-		t.Errorf("main: expected %d, got %d", expected, actual)
 	}
 }


### PR DESCRIPTION
If approved, this PR updates the behavior of the unit test defined in the `slack_test.go` package. It renames the `TestTypeAttachmentDecode` function to `TestTypeAttachmentEncode` and tests the encoding of the type `PostMessage`.

The original test decoded a JSON document into a custom data type. The intended purpose of the test is to ensure that both the `Attachments.Add` method, and the encoding of the type `PostMessage` behave as anticipated.

**Verification steps:**

Test using native go binary:

    $ go test -v ./...

Test using a Docker container:

    $ docker run --rm -v "$PWD":/usr/src/gentry -w /usr/src/gentry golang go test -v ./...