### PR TITLE
Use string instead of int for custom type State

### DIFF
--- a/health.go
+++ b/health.go
@@ -1,34 +1,22 @@
 package main
 
-import (
-	"encoding/json"
-)
+type State string
 
-type State int
-
-func (s *State) UnmarshalJSON(data []byte) error {
-	var state string
-	if err := json.Unmarshal(data, &state); err != nil {
-		return err
-	}
-	switch state {
-	case "critical":
-		*s = StateCritical
-	case "passing":
-		*s = StatePassing
-	case "warning":
-		*s = StateWarning
-	default:
-		*s = StateAny
-	}
+func (s *State) Set(state string) error {
+	*s = State(state)
 	return nil
 }
 
+// String returns the literal text of the state.
+func (s State) String() string {
+	return string(s)
+}
+
 const (
-	StateAny State = iota
-	StateCritical
-	StatePassing
-	StateWarning
+	StateAny      State = "any"
+	StateCritical State = "critical"
+	StatePassing  State = "passing"
+	StateWarning  State = "warning"
 )
 
 type Check struct {

--- a/health_test.go
+++ b/health_test.go
@@ -20,7 +20,7 @@ func TestTypeStateDecode(t *testing.T) {
 	for i, expected := range []State{StateAny, StateCritical, StatePassing, StateWarning} {
 		actual = checks[i].Status
 		if expected != actual {
-			t.Errorf("main: expected type %d, got %d instead", expected, actual)
+			t.Errorf("main: expected %q, got %q instead", expected, actual)
 		}
 	}
 }
@@ -31,5 +31,16 @@ func TestTypeStateDecodeMalformed(t *testing.T) {
 	var checks Checks
 	if err := json.Unmarshal(data, &checks); err == nil {
 		t.Error("main: expected type string, got number instead")
+	}
+}
+
+func TestTypeStateFlagParsing(t *testing.T) {
+	var state State
+	actual, expected := "any", StateAny.String()
+	if err := state.Set(actual); err != nil {
+		t.Error(err)
+	}
+	if expected != actual {
+		t.Errorf("main: expected %q, got %q instead", expected, actual)
 	}
 }


### PR DESCRIPTION
Remove `State.UnmarshalJSON` method since the type of the state (`Status`[1]) returned from the Consul HTTP API is a string. Create `State.Set` and `State.String` methods to implement `flag.Value` interface[2].

References:

1. https://www.consul.io/api/health.html#sample-response-3
2. https://golang.org/pkg/flag/#Value

Closes #21